### PR TITLE
Adds right click context menus

### DIFF
--- a/Components/Description/DescriptionSystem.cs
+++ b/Components/Description/DescriptionSystem.cs
@@ -53,7 +53,7 @@ public partial class DescriptionSystem : NodeSystem
         customTooltip.SetTooltipBulletpoints(descriptionComponent.DetailedSummary);
         CanvasLayer.AddChild(customTooltip);
         var mousePosition = GetViewport().GetMousePosition();
-        customTooltip.SetPosition(new Vector2I((int)mousePosition.X + 16, (int)mousePosition.Y + 16));
+        customTooltip.SetPosition(new Vector2I((int)mousePosition.X + 8, (int)mousePosition.Y + 8));
     }
 
     /// <summary>

--- a/Components/Interaction/InteractableComponent.cs
+++ b/Components/Interaction/InteractableComponent.cs
@@ -3,6 +3,7 @@ using CS.Nodes.UI.Chyron;
 using CS.SlimeFactory;
 using CS.SlimeFactory.Signals;
 using Godot;
+using Godot.Collections;
 
 namespace CS.Components.Interaction;
 
@@ -63,6 +64,17 @@ public partial class InteractWithSignal : HandledSignalArgs
     public Node Interactee;
 
     public InteractWithSignal(Node interactee)
+    {
+        Interactee = interactee;
+    }
+}
+
+public partial class GetContextActionsSignal : UserSignalArgs
+{
+    public Node Interactee;
+    public Array<Button> Actions = [];
+
+    public GetContextActionsSignal(Node interactee)
     {
         Interactee = interactee;
     }

--- a/Nodes/UI/NodeButtonList/NodeButtonListSystem.cs
+++ b/Nodes/UI/NodeButtonList/NodeButtonListSystem.cs
@@ -60,4 +60,16 @@ public partial class NodeButtonListSystem : Control
 			_vBoxContainer.AddChild(button);
 		}
 	}
+
+	public void Setup(Array<Button> buttons)
+	{
+		foreach (var child in _vBoxContainer.GetChildren())
+			child.QueueFree();
+
+		foreach (var button in buttons)
+		{
+			button.Pressed += QueueFree;
+			_vBoxContainer.AddChild(button);
+		}
+	}
 }

--- a/SlimeFactory/Signals/SignalBus.Interact.cs
+++ b/SlimeFactory/Signals/SignalBus.Interact.cs
@@ -11,6 +11,14 @@ public partial class SignalBus
     {
         InteractWithSignal?.Invoke(node, ref args);
     }
+
+    public delegate void GetContextActionsSignalHandler(Node<InteractableComponent> node,
+        ref GetContextActionsSignal args);
+    public event GetContextActionsSignalHandler? GetContextActionsSignal;
+    public void EmitGetContextActionsSignal(Node<InteractableComponent> node, ref GetContextActionsSignal args)
+    {
+        GetContextActionsSignal?.Invoke(node, ref args);
+    }
     
     public delegate void ShowInteractOutlineSignalHandler(Node<CanInteractComponent> node,
         ref ShowInteractOutlineSignal args);


### PR DESCRIPTION
## Brief Summary of Changes
<!-- What is this PR roughly about? -->
On right click, shows a list of nearby nodes or specific actions that can be taken on a single node

## Justification
<!-- Why are you adding this PR? -->
Basic feature and implements https://github.com/SirkkasIdyll/CirkkalsStory/issues/22

## Technical Explanation
<!-- How were things specifically achieved and why did you implement it the way you did? -->
On right click, if a specific target is right clicked, sends out a signal to get context actions on that target in the form of buttons. The buttons are then displayed. Clicking the button will execute the stated action.

If no target is specifically right clicked, it creates a (32, 32) Area2D around the cursor and gets any overlapping bodies that are interactable. Clicking the option will attempt to interact with the object.

## Supporting Media (Optional)
<!-- Any images or videos you'd like to add to demonstrate what this PR adds -->

https://github.com/user-attachments/assets/6793b54f-952b-462f-835b-97134cff62e3


https://github.com/user-attachments/assets/d4b39400-ace6-458c-b9e8-f009f93d4fa6

