### PR TITLE
Makes context option for equipping items specific

### DIFF
--- a/Components/Interaction/InteractSystem.cs
+++ b/Components/Interaction/InteractSystem.cs
@@ -26,7 +26,6 @@ public partial class InteractSystem : NodeSystem
 
         _nodeManager.SignalBus.ShowInteractOutlineSignal += OnShowInteractOutline;
         _nodeManager.SignalBus.HideInteractOutlineSignal += OnHideInteractOutline;
-        _nodeManager.SignalBus.GetContextActionsSignal += OnGetContextActions;
     }
 
     public override void _Input(InputEvent @event)
@@ -234,28 +233,12 @@ public partial class InteractSystem : NodeSystem
         canvasGroup.Material = null;
     }
 
-    private void OnGetContextActions(Node<InteractableComponent> node, ref GetContextActionsSignal args)
-    {
-        var button = new Button();
-        args.Actions.Add(button);
-        button.Text = "Interact";
-
-        if (!_nodeManager.TryGetComponent<CanInteractComponent>(args.Interactee, out var canInteractComponent))
-        {
-            button.Disabled = true;
-            return;
-        }
-
-        var interactee = args.Interactee;
-        button.Pressed += () => OnPrimaryInteract((interactee, canInteractComponent), node);
-    }
-
     /// <summary>
     /// First check if the nodes are within range of each other
     /// then create a raycast from the origin to the target to check for obstructions
     /// Currently just checks if there's an impassable in the way
     /// </summary>
-    private bool InRangeUnobstructed(Node origin, Node target, float range, uint collisionMask = 1)
+    public bool InRangeUnobstructed(Node origin, Node target, float range, uint collisionMask = 1)
     {
         if (!_gridSystem.TryGetDistance(origin, target, out var distance))
             return false;
@@ -276,7 +259,7 @@ public partial class InteractSystem : NodeSystem
         return true;
     }
 
-    private bool IsObstructed(Node origin, Node target, uint collisionMask = 1)
+    public bool IsObstructed(Node origin, Node target, uint collisionMask = 1)
     {
         if (origin is not PhysicsBody2D node2DA || target is not PhysicsBody2D node2DB)
             return false;


### PR DESCRIPTION
## Brief Summary of Changes
<!-- What is this PR roughly about? -->
Removes generic interact context action and replaces it with equip item

## Justification
<!-- Why are you adding this PR? -->
Knowing what is possible is more ideal than just generically interacting with something

## Technical Explanation
<!-- How were things specifically achieved and why did you implement it the way you did? -->
Moved signal listener from the InteractSystem over to the ClothingSystem. Added appropriate checks for things being in range and unobstructed as well.

## Supporting Media (Optional)
<!-- Any images or videos you'd like to add to demonstrate what this PR adds -->

https://github.com/user-attachments/assets/823b4697-4d73-45f1-853b-4b8c96003bb3

