### PR TITLE
Raycasted drop

### DIFF
--- a/Components/Clothing/ClothingSystem.cs
+++ b/Components/Clothing/ClothingSystem.cs
@@ -289,17 +289,35 @@ public partial class ClothingSystem : NodeSystem
         
         if (!TryUnequipClothing(node, ClothingSlot.Inhand, true))
             return false;
-
-        var mousePosition = _gridSystem.GlobalPositionToGridPosition(GetGlobalMousePosition());
-        var nodePosition = _gridSystem.GetPosition(node);
-
-        if (nodePosition == null)
+        
+        var nodeGridPosition = _gridSystem.GetPosition(node);
+        if (nodeGridPosition == null)
             return false;
         
-        var distanceVector = new Vector2(mousePosition.X - nodePosition.Value.X, mousePosition.Y - nodePosition.Value.Y);
-        var limitedDistanceVector = distanceVector.LimitLength(canInteractComponent.MaxInteractDistance * 0.9f);
-        _gridSystem.SetPosition(inhandItem, nodePosition.Value + limitedDistanceVector);
         
+        if (_interactSystem.IsObstructed(node, GetGlobalMousePosition(), out var collisionInfo)
+            && node.Owner is Node2D node2D)
+        {
+            var collisionPosition = (Vector2)collisionInfo["position"];
+            var distanceToCollisionVector = new Vector2(collisionPosition.X - node2D.GlobalPosition.X,
+                collisionPosition.Y - node2D.GlobalPosition.Y);
+
+            if (inhandItem is Node2D itemNode2D)
+            {
+                itemNode2D.SetGlobalPosition(itemNode2D.GlobalPosition + distanceToCollisionVector
+                    .LimitLength(canInteractComponent.MaxInteractDistance * 32f * 0.9f));
+            }
+        }
+        else
+        {
+            var mouseGridPosition = _gridSystem.GlobalPositionToGridPosition(GetGlobalMousePosition());
+            var distanceVector = new Vector2(mouseGridPosition.X - nodeGridPosition.Value.X,
+                mouseGridPosition.Y - nodeGridPosition.Value.Y);
+            
+            var addToPosition = distanceVector.LimitLength(canInteractComponent.MaxInteractDistance * 0.9f);
+            _gridSystem.SetPosition(inhandItem, nodeGridPosition.Value + addToPosition);
+        }
+       
         return true;
     }
 


### PR DESCRIPTION
## Brief Summary of Changes
<!-- What is this PR roughly about? -->
Updates the drop function to check for obstructions and drops the item at the collision point instead

## Justification
<!-- Why are you adding this PR? -->
So you can't drop stuff over walls

## Technical Explanation
<!-- How were things specifically achieved and why did you implement it the way you did? -->
Things still get sent into the hell dimension whenever you set something on top of something it collides with a little too deep, not sure where they go or what I'll do to fix it.

## Supporting Media (Optional)
<!-- Any images or videos you'd like to add to demonstrate what this PR adds -->

https://github.com/user-attachments/assets/b3ad4c8b-bc78-412f-ab20-9125621416cc

