### PR TITLE
Drop now uses MoveAndCollide

### DIFF
--- a/Components/Clothing/ClothingSystem.cs
+++ b/Components/Clothing/ClothingSystem.cs
@@ -3,6 +3,7 @@ using CS.Components.Appearance;
 using CS.Components.Grid;
 using CS.Components.Interaction;
 using CS.Components.Inventory;
+using CS.Components.Movement;
 using CS.Components.Player;
 using CS.Components.UI;
 using CS.Nodes.Scenes.Inventory;
@@ -289,34 +290,23 @@ public partial class ClothingSystem : NodeSystem
         
         if (!TryUnequipClothing(node, ClothingSlot.Inhand, true))
             return false;
-        
-        var nodeGridPosition = _gridSystem.GetPosition(node);
-        if (nodeGridPosition == null)
-            return false;
-        
-        
-        if (_interactSystem.IsObstructed(node, GetGlobalMousePosition(), out var collisionInfo)
-            && node.Owner is Node2D node2D)
-        {
-            var collisionPosition = (Vector2)collisionInfo["position"];
-            var distanceToCollisionVector = new Vector2(collisionPosition.X - node2D.GlobalPosition.X,
-                collisionPosition.Y - node2D.GlobalPosition.Y);
 
-            if (inhandItem is Node2D itemNode2D)
-            {
-                itemNode2D.SetGlobalPosition(itemNode2D.GlobalPosition + distanceToCollisionVector
-                    .LimitLength(canInteractComponent.MaxInteractDistance * 32f * 0.9f));
-            }
-        }
-        else
-        {
-            var mouseGridPosition = _gridSystem.GlobalPositionToGridPosition(GetGlobalMousePosition());
-            var distanceVector = new Vector2(mouseGridPosition.X - nodeGridPosition.Value.X,
-                mouseGridPosition.Y - nodeGridPosition.Value.Y);
-            
-            var addToPosition = distanceVector.LimitLength(canInteractComponent.MaxInteractDistance * 0.9f);
-            _gridSystem.SetPosition(inhandItem, nodeGridPosition.Value + addToPosition);
-        }
+        if (node.Owner is not Node2D node2D)
+            return false;
+
+        _nodeManager.TryAddComponent<MoveUntilCollideComponent>(inhandItem);
+
+        if (!_nodeManager.TryGetComponent<MoveUntilCollideComponent>(inhandItem, out var moveUntilCollideComponent))
+            return false;
+
+        var mousePosition = GetGlobalMousePosition();
+        var destinationVector = new Vector2(mousePosition.X - node2D.Position.X, mousePosition.Y - node2D.Position.Y);
+        moveUntilCollideComponent.Timed = true;
+        moveUntilCollideComponent.RemoveOnCollide = true;
+        moveUntilCollideComponent.TimeRemaining = 0.05f;
+        moveUntilCollideComponent.MotionVector =
+            destinationVector.LimitLength(canInteractComponent.MaxInteractDistance * GridSystem.TileSize * 0.9f)
+            / moveUntilCollideComponent.TimeRemaining;
        
         return true;
     }

--- a/Components/Clothing/ClothingSystem.cs
+++ b/Components/Clothing/ClothingSystem.cs
@@ -302,7 +302,6 @@ public partial class ClothingSystem : NodeSystem
         var mousePosition = GetGlobalMousePosition();
         var destinationVector = new Vector2(mousePosition.X - node2D.Position.X, mousePosition.Y - node2D.Position.Y);
         moveUntilCollideComponent.Timed = true;
-        moveUntilCollideComponent.RemoveOnCollide = true;
         moveUntilCollideComponent.TimeRemaining = 0.05f;
         moveUntilCollideComponent.MotionVector =
             destinationVector.LimitLength(canInteractComponent.MaxInteractDistance * GridSystem.TileSize * 0.9f)

--- a/Components/Clothing/ClothingSystem.cs
+++ b/Components/Clothing/ClothingSystem.cs
@@ -291,11 +291,11 @@ public partial class ClothingSystem : NodeSystem
         if (!TryUnequipClothing(node, ClothingSlot.Inhand, true))
             return false;
 
+        // Get the owner's position so we can get the vector from owner to mouse
         if (node.Owner is not Node2D node2D)
             return false;
-
+        
         _nodeManager.TryAddComponent<MoveUntilCollideComponent>(inhandItem);
-
         if (!_nodeManager.TryGetComponent<MoveUntilCollideComponent>(inhandItem, out var moveUntilCollideComponent))
             return false;
 
@@ -401,6 +401,7 @@ public partial class ClothingSystem : NodeSystem
             {
                 node.Comp.ClothingSlots[ClothingSlot.Inhand] = item;
                 item.Comp.StoredBy = node;
+                itemNode2D.SetGlobalRotation(0); // Reset position so dropping it is normal
                 
                 var signal = new ItemPutInHandSignal(item);
                 _nodeManager.SignalBus.EmitItemPutInHandSignal(node, ref signal);

--- a/Components/Movement/MoveUntilCollideComponent.cs
+++ b/Components/Movement/MoveUntilCollideComponent.cs
@@ -1,0 +1,75 @@
+﻿using CS.SlimeFactory;
+using Godot;
+
+namespace CS.Components.Movement;
+
+/// <summary>
+/// Moves the parent body until collision, 
+/// at which point an event will be thrown that other systems can react to
+/// </summary>
+public partial class MoveUntilCollideComponent : Component
+{
+    /// <summary>
+    /// Moves the body along the vector motion
+    /// </summary>
+    [Export]
+    public Vector2 MotionVector;
+    
+    /// <summary>
+    /// Remove this component after collision occurs
+    /// </summary>
+    [Export]
+    public bool RemoveOnCollide;
+    
+    /// <summary>
+    /// Margin beyond the collision body to consider the objects colliding,
+    /// which pushes the body away before motion occurs.
+    /// This does not affect the movement collision.
+    /// </summary>
+    [Export]
+    public float SafeMarginCollision = 0.08f;
+
+    /// <summary>
+    /// When set, will tick down TimeRemaining and stop movement when TimeRemaining reaches zero
+    /// </summary>
+    [Export]
+    public bool Timed;
+    
+    /// <summary>
+    /// Ticks down when Timed is set, stops movement when time reaches zero
+    /// </summary>
+    [Export]
+    public float TimeRemaining;
+    
+    // Having all of this in the component isn't that bad of a sin
+    private readonly NodeManager _nodeManager = NodeManager.Instance;
+    private readonly NodeSystemManager _nodeSystemManager = NodeSystemManager.Instance;
+    
+    public override void _PhysicsProcess(double delta)
+    {
+        base._PhysicsProcess(delta);
+
+        if (MotionVector == Vector2.Zero)
+            return;
+
+        if (GetParent() is not PhysicsBody2D physicsBody2D)
+            return;
+
+        if (Timed && TimeRemaining > 0)
+            TimeRemaining -= (float)delta;
+        
+        var kinematicCollision2D = physicsBody2D.MoveAndCollide(MotionVector * (float)delta, safeMargin: SafeMarginCollision);
+        
+        if (Timed && TimeRemaining <= 0)
+        {
+            MotionVector = Vector2.Zero;
+            return;
+        }
+
+        if (kinematicCollision2D == null)
+            return;
+
+        if (RemoveOnCollide)
+            _nodeManager.RemoveComponent<MoveUntilCollideComponent>(GetParent());
+    }
+}

--- a/Components/Movement/MoveUntilCollideComponent.cs
+++ b/Components/Movement/MoveUntilCollideComponent.cs
@@ -14,12 +14,18 @@ public partial class MoveUntilCollideComponent : Component
     /// </summary>
     [Export]
     public Vector2 MotionVector;
-    
+
     /// <summary>
     /// Remove this component after collision occurs
     /// </summary>
     [Export]
-    public bool RemoveOnCollide;
+    public bool RemoveOnCollide = true;
+
+    /// <summary>
+    /// Remove this component if time elapses
+    /// </summary>
+    [Export]
+    public bool RemoveOnTimeElapsed = true;
     
     /// <summary>
     /// Margin beyond the collision body to consider the objects colliding,
@@ -61,14 +67,16 @@ public partial class MoveUntilCollideComponent : Component
         var kinematicCollision2D = physicsBody2D.MoveAndCollide(MotionVector * (float)delta, safeMargin: SafeMarginCollision);
         
         if (Timed && TimeRemaining <= 0)
-        {
             MotionVector = Vector2.Zero;
-            return;
-        }
+        
+        if (RemoveOnTimeElapsed && Timed && TimeRemaining <= 0)
+            _nodeManager.RemoveComponent<MoveUntilCollideComponent>(GetParent());
 
+        // When null, no collision has occurred
         if (kinematicCollision2D == null)
             return;
-
+        
+        // If a collision has occurred, remove component if setting is set
         if (RemoveOnCollide)
             _nodeManager.RemoveComponent<MoveUntilCollideComponent>(GetParent());
     }

--- a/Components/Player/PlayerManagerSystem.cs
+++ b/Components/Player/PlayerManagerSystem.cs
@@ -7,13 +7,7 @@ namespace CS.Components.Player;
 public partial class PlayerManagerSystem : NodeSystem
 {
     private Node? _player;
-
-    /// <summary>
-    /// TODO: HUNT DOWN ALL USAGES OF THIS AND UNCURSE IT
-    /// UNCURSE IT BY MAKING SESSIONS A THING, ALTHOUGH THIS IS KIND OF A SESSION
-    /// NO NULL SAFETY, NOTHING IS GOOD ABOUT THIS
-    /// 
-    /// </summary>
+    
     public Node? TryGetPlayer()
     {
         return _player;

--- a/SlimeFactory/NodeManager.cs
+++ b/SlimeFactory/NodeManager.cs
@@ -130,13 +130,13 @@ public partial class NodeManager
     /// <summary>
     /// Checks if GetNodeOrNull returns the type of T
     /// </summary>
-    public bool HasComponent<T>(Node node) where T : class, IComponent
+    public bool HasComponent<T>(Node node) where T : Component, IComponent
     {
         var comp = node.GetNodeOrNull<T>($"{typeof(T).Name}");
         return comp != null;
     }
     
-    public bool TryAddComponent<T>(Node node) where T : class, IComponent
+    public bool TryAddComponent<T>(Node node) where T : Component, IComponent
     {
         CompDictionary.TryGetValue(typeof(T).Name, out var component);
 
@@ -152,10 +152,24 @@ public partial class NodeManager
     /// <summary>
     /// Checks if GetNodeOrNull returns the type of T and returns the Node
     /// </summary>
-    public bool TryGetComponent<T>(Node node, [NotNullWhen(true)] out T? component) where T : class, IComponent
+    public bool TryGetComponent<T>(Node node, [NotNullWhen(true)] out T? component) where T : Component, IComponent
     {
         component = node.GetNodeOrNull<T>($"{typeof(T).Name}");
         return component != null;
+    }
+
+    /// <summary>
+    /// Removes the component if it exists and is a child of the node
+    /// QueueFrees the component as well
+    /// </summary>
+    public void RemoveComponent<T>(Node node) where T : Component, IComponent 
+    {
+        var component = node.GetNodeOrNull<T>($"{typeof(T).Name}");
+        if (component == null)
+            return;
+        
+        node.RemoveChild(component);
+        component.QueueFree();
     }
 
     /// <summary>


### PR DESCRIPTION
## Brief Summary of Changes
<!-- What is this PR roughly about? -->
Rather than setting the position directly, which is discouraged, we now use the Godot **MoveAndCollide()** function which moves the item in space towards the target and then stops the target upon collision.

## Justification
<!-- Why are you adding this PR? -->
Setting the position manually like I was doing before was sending items to the hell dimension when depenetration occurred.

## Technical Explanation
<!-- How were things specifically achieved and why did you implement it the way you did? -->
The MoveUntilCollideComponent can be temporarily added to nodes to... move them, until it collides with something or until a given amount of time passes. Upon collision or time elapsing, the component removes itself from the node.

This is a more clean solution that can be reused for other cases.

## Supporting Media (Optional)
<!-- Any images or videos you'd like to add to demonstrate what this PR adds -->

https://github.com/user-attachments/assets/dd1a5115-4dbf-4019-9845-b46ae4338024

